### PR TITLE
Bump elasticsearch to 0.90.2

### DIFF
--- a/files/brews/elasticsearch.rb
+++ b/files/brews/elasticsearch.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Elasticsearch < Formula
   homepage 'http://www.elasticsearch.org'
-  url 'http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.20.2.tar.gz'
-  sha1 '9bedb3638e4fc5a53e264aab3c5ff1a345f22bab'
-  version '0.20.2-boxen1'
+  url 'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.2.tar.gz'
+  sha1 'b09f5c656912e5c08c9eefa7e95566f1ba7a1ea5'
+  version '0.90.2-boxen1'
 
   def cluster_name
     "elasticsearch_#{ENV['USER']}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class elasticsearch {
   }
 
   package { 'boxen/brews/elasticsearch':
-    ensure  => '0.20.2-boxen1',
+    ensure  => '0.90.2-boxen1',
     notify  => Service['dev.elasticsearch'],
     require => Class['java'],
   }

--- a/spec/classes/elasticsearch_spec.rb
+++ b/spec/classes/elasticsearch_spec.rb
@@ -38,7 +38,7 @@ describe 'elasticsearch' do
     })
 
     should contain_package('boxen/brews/elasticsearch').with({
-      :ensure => '0.20.2-boxen1',
+      :ensure => '0.90.2-boxen1',
       :notify => 'Service[dev.elasticsearch]',
     })
 


### PR DESCRIPTION
Bumps to latest stable version `0.90.2`

http://www.elasticsearch.org/download/
