### PR TITLE
Don't disable all dynamic scripts

### DIFF
--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -41,6 +41,3 @@ discovery:
       unicast:
         hosts:
           - <%= @host %>:<%= @transport_port %>
-
-script:
-  disable_dynamic: true


### PR DESCRIPTION
As of ES 1.3, the default is to allow dynamic scripts in sandboxed
languages, eg. Groovy.

Unless I'm missing something, it should be safe to go with the default
here.
