### PR TITLE
Bump version to 1.4.3

### DIFF
--- a/files/brews/elasticsearch.rb
+++ b/files/brews/elasticsearch.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Elasticsearch < Formula
   homepage "http://www.elasticsearch.org"
-  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.0.tar.gz"
-  sha1 "728913722bc94dad4cb5e759a362f09dc19ed6fe"
-  version '1.4.0-boxen1'
+  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.3.tar.gz"
+  sha1 "d26828bef335a164175f5af14a2a7fc44cb063f2"
+  version '1.4.3-boxen1'
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class elasticsearch::params {
 
       $ensure         = 'present'
 
-      $version        = '1.4.0-boxen1'
+      $version        = '1.4.3-boxen1'
       $package        = 'boxen/brews/elasticsearch'
 
       $cluster        = "elasticsearch_boxen_${::boxen_user}"

--- a/spec/classes/elasticsearch_package_spec.rb
+++ b/spec/classes/elasticsearch_package_spec.rb
@@ -6,6 +6,6 @@ describe "elasticsearch::package" do
   it do
     should contain_homebrew__formula("elasticsearch")
 
-    should contain_package("boxen/brews/elasticsearch").with_ensure("1.4.0-boxen1")
+    should contain_package("boxen/brews/elasticsearch").with_ensure("1.4.3-boxen1")
   end
 end


### PR DESCRIPTION
I needed 1.4.3 since I wanted to try the latest Kibana beta, which
requires it. So I did this :)