### PR TITLE
Remove Ruby 1.8.7 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:
-  - "1.8.7"
   - "2.0.0"


### PR DESCRIPTION
See https://github.com/boxen/puppet-boxen/commit/2abbcaac4bc64d5c15ccc08a913005c48eb44d2f for reference.

Is there any reason we want to keep 1.8.7, and should dive into why the tests are failing?

/cc @rafaelfranca @mikemcquaid 