### PR TITLE
Elasticsearch 1.7.1

### DIFF
--- a/files/brews/elasticsearch.rb
+++ b/files/brews/elasticsearch.rb
@@ -1,13 +1,13 @@
 require "formula"
 
 class Elasticsearch < Formula
-  homepage "http://www.elasticsearch.org"
-  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.tar.gz"
+  homepage "http://www.elastic.co"
+  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.tar.gz"
   sha1 "ffe2e46ec88f4455323112a556adaaa085669d13"
   version '1.5.2-boxen1'
 
   head do
-    url "https://github.com/elasticsearch/elasticsearch.git"
+    url "https://github.com/elastic/elasticsearch.git"
     depends_on "maven"
   end
 

--- a/files/brews/elasticsearch.rb
+++ b/files/brews/elasticsearch.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Elasticsearch < Formula
   homepage "http://www.elastic.co"
-  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.tar.gz"
+  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"
   sha1 "ffe2e46ec88f4455323112a556adaaa085669d13"
-  version '1.5.2-boxen1'
+  version '1.7.1-boxen1'
 
   head do
     url "https://github.com/elastic/elasticsearch.git"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class elasticsearch::params {
 
       $ensure         = 'present'
 
-      $version        = '1.5.2-boxen1'
+      $version        = '1.7.1-boxen1'
       $package        = 'boxen/brews/elasticsearch'
 
       $cluster        = "elasticsearch_boxen_${::boxen_user}"

--- a/spec/classes/elasticsearch_package_spec.rb
+++ b/spec/classes/elasticsearch_package_spec.rb
@@ -6,6 +6,6 @@ describe "elasticsearch::package" do
   it do
     should contain_homebrew__formula("elasticsearch")
 
-    should contain_package("boxen/brews/elasticsearch").with_ensure("1.5.2-boxen1")
+    should contain_package("boxen/brews/elasticsearch").with_ensure("1.7.1-boxen1")
   end
 end


### PR DESCRIPTION
Includes the fix (https://github.com/elastic/elasticsearch/pull/12487) for a data loss bug (https://github.com/elastic/elasticsearch/issues/12041).